### PR TITLE
Treat EPERM as stale lock in LeaveBe lock acquisition

### DIFF
--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -237,7 +237,7 @@ pub fn acquire_lock_file<
                     Some(lock_file)
                 }
                 LockAlreadyOwnedActionKind::LeaveBe => match test_kill_process(pid) {
-                    Err(Errno::SRCH) => Some(lock_file),
+                    Err(Errno::SRCH | Errno::PERM) => Some(lock_file),
                     r => {
                         return r
                             .map_io_err(|| {


### PR DESCRIPTION
## Summary

After a hard reboot, the PID stored in `server.lock` can be reused by a process owned by a different user (e.g., PID 1 / init). When this happens, `test_kill_process` returns `EPERM` instead of `ESRCH`, causing the server to fail with:

```
Error: an I/O error occurred
╰─▶ Operation not permitted (os error 1)
    ╰╴Failed to check lock file "server.lock" owner status: Pid(...)
```

The server never recovers, and because `ringboard-x11.service` has `BindsTo=ringboard-server.service`, clipboard monitoring also stops. The only fix is manually deleting the lock file.

## Fix

Add `Errno::PERM` alongside `Errno::SRCH` in the `LeaveBe` match arm of `acquire_lock_file`. This is safe because:

- `ringboard-server` runs as the current user via a user-level systemd unit
- The lock file is in the user's home directory (`~/.local/share/clipboard-history/`)
- `EPERM` from `kill(pid, 0)` means the PID belongs to a different user — it cannot be our server
- The existing recovery code already safely handles cleanup with inode verification

## Test plan

- [x] Write PID 1 (root-owned init process) to `server.lock` to simulate post-reboot PID reuse
- [x] Confirm unpatched server fails with "Operation not permitted"
- [x] Confirm patched server recovers and starts successfully
- [x] `cargo build -p clipboard-history-server` compiles cleanly