### PR TITLE
fix: install script download errors and systemd watcher reliability

### DIFF
--- a/install-with-cargo-systemd.sh
+++ b/install-with-cargo-systemd.sh
@@ -1,17 +1,28 @@
 #!/usr/bin/env bash
 set -e
 
-curl -s https://raw.githubusercontent.com/SUPERCILEX/clipboard-history/master/ringboard.slice --create-dirs -O --output-dir ~/.config/systemd/user/
+# Downloads $1 to the curl args in $2.., failing loudly (instead of silently
+# writing an empty/error-page file) if the request doesn't succeed.
+fetch() {
+  local url="$1"
+  shift
+  if ! curl -sSfL "$url" "$@"; then
+    echo "Failed to download $url" >&2
+    exit 1
+  fi
+}
+
+fetch https://raw.githubusercontent.com/SUPERCILEX/clipboard-history/master/ringboard.slice --create-dirs -O --output-dir ~/.config/systemd/user/
 
 cargo install clipboard-history-server --no-default-features --features systemd
-curl -s https://raw.githubusercontent.com/SUPERCILEX/clipboard-history/master/server/ringboard-server.service --create-dirs -O --output-dir ~/.config/systemd/user/
+fetch https://raw.githubusercontent.com/SUPERCILEX/clipboard-history/master/server/ringboard-server.service --create-dirs -O --output-dir ~/.config/systemd/user/
 sed -i "s|ExecStart=ringboard-server|ExecStart=$(which ringboard-server)|g" ~/.config/systemd/user/ringboard-server.service
 
 cargo install clipboard-history
 
 cargo install clipboard-history-egui --no-default-features --features $XDG_SESSION_TYPE,avif || cargo install clipboard-history-egui --no-default-features --features $XDG_SESSION_TYPE
-curl -s https://raw.githubusercontent.com/SUPERCILEX/clipboard-history/master/egui/ringboard-egui.desktop --create-dirs -O --output-dir ~/.local/share/applications/
-curl -s https://raw.githubusercontent.com/SUPERCILEX/clipboard-history/master/logo.jpeg -o ringboard.jpeg --create-dirs -O --output-dir ~/.local/share/icons/hicolor/1024x1024/
+fetch https://raw.githubusercontent.com/SUPERCILEX/clipboard-history/master/egui/ringboard-egui.desktop --create-dirs -O --output-dir ~/.local/share/applications/
+fetch https://raw.githubusercontent.com/SUPERCILEX/clipboard-history/master/logo.jpeg -o ringboard.jpeg --create-dirs -O --output-dir ~/.local/share/icons/hicolor/1024x1024/
 sed -i "s|Exec=ringboard-egui|Exec=$(echo $(which ringboard-egui) toggle)|g" ~/.local/share/applications/ringboard-egui.desktop
 sed -i "s|Icon=ringboard|Icon=$HOME/.local/share/icons/hicolor/1024x1024/ringboard.jpeg|g" ~/.local/share/applications/ringboard-egui.desktop
 
@@ -27,12 +38,13 @@ if [ "$XDG_SESSION_TYPE" = "wayland" ]; then
 fi
 
 cargo install clipboard-history-$XDG_SESSION_TYPE --no-default-features
-curl -s https://raw.githubusercontent.com/SUPERCILEX/clipboard-history/master/$XDG_SESSION_TYPE/ringboard-$XDG_SESSION_TYPE.service -O --output-dir ~/.config/systemd/user/
+fetch https://raw.githubusercontent.com/SUPERCILEX/clipboard-history/master/$XDG_SESSION_TYPE/ringboard-$XDG_SESSION_TYPE.service --create-dirs -O --output-dir ~/.config/systemd/user/
 sed -i "s|ExecStart=ringboard-$XDG_SESSION_TYPE|ExecStart=$(which ringboard-$XDG_SESSION_TYPE)|g" ~/.config/systemd/user/ringboard-$XDG_SESSION_TYPE.service
 
 killall ringboard-egui ringboard-tui 2> /dev/null || true
 
-systemctl --user stop ringboard-server
+# The service won't exist yet on a first install.
+systemctl --user stop ringboard-server 2> /dev/null || true
 systemctl --user daemon-reload
 systemctl --user start ringboard-server
 systemctl --user enable ringboard-$XDG_SESSION_TYPE --now

--- a/wayland/ringboard-wayland.service
+++ b/wayland/ringboard-wayland.service
@@ -3,7 +3,7 @@ Description=Wayland Ringboard clipboard listener
 Documentation=https://github.com/SUPERCILEX/clipboard-history
 Requires=ringboard-server.service
 After=ringboard-server.service
-BindsTo=graphical-session.target
+PartOf=graphical-session.target
 After=graphical-session.target
 
 [Service]
@@ -11,6 +11,7 @@ Type=exec
 Environment=RUST_LOG=trace
 ExecStart=ringboard-wayland
 Restart=on-failure
+RestartSec=5
 Slice=ringboard.slice
 
 [Install]

--- a/x11/ringboard-x11.service
+++ b/x11/ringboard-x11.service
@@ -3,7 +3,7 @@ Description=X11 Ringboard clipboard listener
 Documentation=https://github.com/SUPERCILEX/clipboard-history
 Requires=ringboard-server.service
 After=ringboard-server.service
-BindsTo=graphical-session.target
+PartOf=graphical-session.target
 After=graphical-session.target
 
 [Service]
@@ -11,6 +11,7 @@ Type=exec
 Environment=RUST_LOG=trace
 ExecStart=ringboard-x11
 Restart=on-failure
+RestartSec=5
 Slice=ringboard.slice
 
 [Install]


### PR DESCRIPTION
Cherry-picks the targeted fixes from #105 (install script hardening and systemd watcher reliability) into a standalone PR.

**install script**
- Route all `curl` calls through a `fetch()` helper using `-sSfL` so a failed download (404, network error, etc.) aborts immediately with a clear message instead of silently writing an error page as the real file.
- Add missing `--create-dirs` to the `$XDG_SESSION_TYPE` service download, making it consistent with every other curl call in the script.
- Make `systemctl --user stop ringboard-server` idempotent so a first-time install (no prior service) doesn't abort under `set -e`.

**systemd watcher units**
- Replace `BindsTo=graphical-session.target` with `PartOf=` in both watcher units. Both directives stop the watcher when the session ends and leave the target unaffected when the watcher crashes. The key difference is that `PartOf=` restarts the watcher when the session restarts, whereas `BindsTo=` stops it and only starts it again if separately pulled in (e.g. via `WantedBy=`). This makes `PartOf=` a better fit for clipboard watchers that should follow the session lifecycle without pulling in the target when manually started.
- Add `RestartSec=5` to both watcher units so `Restart=on-failure` doesn't burn through systemd's start-rate limit on repeated crashes.